### PR TITLE
Incremental CGAL capabilities

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
       - run: pip install . --user
       - run: pip3 install -U pytest pytest-cov --user
       - run:
-          command: cd tests && pytest --cov -m "serial" --source=. #&& mpirun -np 2 pytest --cov -m "parallel" .
+          command: cd tests && pytest --cov -m "serial" --source= . #&& mpirun -np 2 pytest --cov -m "parallel" .
       - run: bash <(curl -s https://codecov.io/bash)
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
       - run: pip install . --user
       - run: pip3 install -U pytest pytest-cov --user
       - run:
-          command: cd tests && pytest --cov -m "serial" --source= . #&& mpirun -np 2 pytest --cov -m "parallel" .
+          command: py.test --cov SeismicMesh tests/ -m "serial" #&& mpirun -np 2 pytest --cov -m "parallel" .
       - run: bash <(curl -s https://codecov.io/bash)
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
       - run: pip install . --user
       - run: pip3 install -U pytest pytest-cov --user
       - run:
-          command: cd tests && pytest --cov -m "serial" . #&& mpirun -np 2 pytest --cov -m "parallel" .
+          command: cd tests && pytest --cov -m "serial" --source=. #&& mpirun -np 2 pytest --cov -m "parallel" .
       - run: bash <(curl -s https://codecov.io/bash)
 workflows:
   version: 2

--- a/SeismicMesh/generation/cpp/delaunay_class.cpp
+++ b/SeismicMesh/generation/cpp/delaunay_class.cpp
@@ -176,7 +176,7 @@ PYBIND11_MODULE(delaunay_class, m)
                  return py::make_iterator(dt.finite_vertices_begin(), dt.finite_vertices_end());
              })
 
-            .def("get_finite_faces", [](DT & dt)
+            .def("get_finite_cells", [](DT & dt)
             {
               // ouput the face table
               // YOU MUST CALL get_finite_vertices before if any incremental operations

--- a/SeismicMesh/generation/cpp/delaunay_class.cpp
+++ b/SeismicMesh/generation/cpp/delaunay_class.cpp
@@ -26,7 +26,7 @@ using DT = CGAL::Delaunay_triangulation_2<K, Tds>;
 
 using Point = K::Point_2;
 using Vertex_handle = DT::Vertex_handle;
-using Vi = DT::Vertex_iterator;
+using Vi = DT::Finite_vertices_iterator;
 
 
 template <typename T>
@@ -130,7 +130,7 @@ PYBIND11_MODULE(delaunay_class, m)
             .def("remove", [](DT & dt, const std::vector<unsigned int> & to_remove) {
                     int num_to_remove= to_remove.size();
                     std::vector<Vertex_handle> handles;
-                    for (Vi vi = dt.vertices_begin(); vi != dt.vertices_end(); vi++){
+                    for (Vi vi = dt.finite_vertices_begin(); vi != dt.finite_vertices_end(); vi++){
                         handles.push_back(vi);
                     }
                     for(std::size_t i=0; i < num_to_remove; ++i){
@@ -144,7 +144,7 @@ PYBIND11_MODULE(delaunay_class, m)
                     std::vector<Point> new_pos;
                     int num_to_move= to_move.size();
                     // store all vertex handles
-                    for (Vi vi = dt.vertices_begin(); vi != dt.vertices_end(); vi++){
+                    for (Vi vi = dt.finite_vertices_begin(); vi != dt.finite_vertices_end(); vi++){
                         handles.push_back(vi);
                     }
                     // store new positions as a vector of Point

--- a/SeismicMesh/generation/cpp/delaunay_class3.cpp
+++ b/SeismicMesh/generation/cpp/delaunay_class3.cpp
@@ -146,10 +146,25 @@ PYBIND11_MODULE(delaunay_class3, m)
                     //
                     for(std::size_t i = 0; i < num_to_move; ++i)
                     {
+                    if(!dt.is_infinite(handles[to_move[i]])){
                        dt.move( handles[to_move[i]], new_pos[i] );
+                       }
                     }
                     return dt;
                     })
+
+            .def("remove", [](DT & dt, const std::vector<unsigned int> & to_remove) {
+                    int num_to_remove= to_remove.size();
+                    std::vector<Vertex_handle> handles;
+                    for (Vi vi = dt.vertices_begin(); vi != dt.vertices_end(); vi++){
+                        handles.push_back(vi);
+                    }
+                    for(std::size_t i=0; i < num_to_remove; ++i){
+                        dt.remove(handles[to_remove[i]]);
+                    }
+                    return dt;
+                })
+
 
             .def("number_of_vertices", [](DT & dt){
                     return dt.number_of_vertices();

--- a/SeismicMesh/generation/cpp/delaunay_class3.cpp
+++ b/SeismicMesh/generation/cpp/delaunay_class3.cpp
@@ -25,7 +25,7 @@ using DT = CGAL::Delaunay_triangulation_3<K, Tds>;
 
 using Point = K::Point_3;
 using Vertex_handle = DT::Vertex_handle;
-using Vi = DT::Vertex_iterator;
+using Vi = DT::Finite_vertices_iterator;
 
 
 template <typename T>
@@ -135,7 +135,8 @@ PYBIND11_MODULE(delaunay_class3, m)
                     std::vector<Point> new_pos;
                     int num_to_move= to_move.size();
                     // store all vertex handles
-                    for (Vi vi = dt.vertices_begin(); vi != dt.vertices_end(); vi++){
+                    // Should this be finite_vertices_begin and finite_vertices_end?
+                    for (Vi vi = dt.finite_vertices_begin(); vi != dt.finite_vertices_end(); vi++){
                         handles.push_back(vi);
                     }
                     // store new positions as a vector of Point
@@ -146,9 +147,7 @@ PYBIND11_MODULE(delaunay_class3, m)
                     //
                     for(std::size_t i = 0; i < num_to_move; ++i)
                     {
-                    if(!dt.is_infinite(handles[to_move[i]])){
                        dt.move( handles[to_move[i]], new_pos[i] );
-                       }
                     }
                     return dt;
                     })
@@ -156,7 +155,7 @@ PYBIND11_MODULE(delaunay_class3, m)
             .def("remove", [](DT & dt, const std::vector<unsigned int> & to_remove) {
                     int num_to_remove= to_remove.size();
                     std::vector<Vertex_handle> handles;
-                    for (Vi vi = dt.vertices_begin(); vi != dt.vertices_end(); vi++){
+                    for (Vi vi = dt.finite_vertices_begin(); vi != dt.finite_vertices_end(); vi++){
                         handles.push_back(vi);
                     }
                     for(std::size_t i=0; i < num_to_remove; ++i){

--- a/SeismicMesh/generation/mesh_generator.py
+++ b/SeismicMesh/generation/mesh_generator.py
@@ -315,9 +315,7 @@ class MeshGenerator:  # noqa: C901
                     dt = DT()
                     dt.insert(p.flatten().tolist())
                 else:
-                    # what points moved?
-                    to_move = np.where(dist(p, pold) > 0.00)[0]
-                    print(len(to_move))
+                    to_move = np.where(dist(p, pold) > 0)[0]
                     dt.move(to_move.flatten().tolist(), p[to_move].flatten().tolist())
 
             # Get the current topology of the triangulation

--- a/SeismicMesh/geometry/utils.py
+++ b/SeismicMesh/geometry/utils.py
@@ -55,12 +55,8 @@ def remove_external_entities(vertices, entities, extent, dim=2):
     :param dim: dimension of mesh
     :type dim: int, optional
 
-    :return: vertices_new: point coordinates of mesh w/ removed entities
-    :rtype: numpy.ndarray[float64 x dim]
-    :return: entities_new: mesh connectivity w/ removed entities
-    :rtype: numpy.ndarray[int x (dim +1)]
-    :return: jx: mapping from old point indexing to new point indexing
-    :rtype: numpy.ndarray[int x 1]
+    :return: isOut: point indices to remove
+    :rtype: numpy.ndarray[float64 x 1]
     """
 
     if dim == 2:
@@ -82,9 +78,7 @@ def remove_external_entities(vertices, entities, extent, dim=2):
             z2=extent[5],
         )
     isOut = np.reshape(signed_distance > 0.0, (-1, (dim + 1)))
-    entities_new = entities[(np.sum(isOut, axis=1) != (dim + 1))]
-    vertices_new, entities_new, jx = fixmesh(vertices, entities_new, dim=dim)
-    return vertices_new, entities_new, jx
+    return isOut
 
 
 def vertex_to_entities(vertices, entities, dim=2):

--- a/SeismicMesh/geometry/utils.py
+++ b/SeismicMesh/geometry/utils.py
@@ -55,8 +55,12 @@ def remove_external_entities(vertices, entities, extent, dim=2):
     :param dim: dimension of mesh
     :type dim: int, optional
 
-    :return: isOut: point indices to remove
-    :rtype: numpy.ndarray[float64 x 1]
+    :return: vertices_new: point coordinates of mesh w/ removed entities
+    :rtype: numpy.ndarray[float64 x dim]
+    :return: entities_new: mesh connectivity w/ removed entities
+    :rtype: numpy.ndarray[int x (dim +1)]
+    :return: jx: mapping from old point indexing to new point indexing
+    :rtype: numpy.ndarray[int x 1]
     """
 
     if dim == 2:
@@ -78,7 +82,9 @@ def remove_external_entities(vertices, entities, extent, dim=2):
             z2=extent[5],
         )
     isOut = np.reshape(signed_distance > 0.0, (-1, (dim + 1)))
-    return isOut
+    entities_new = entities[(np.sum(isOut, axis=1) != (dim + 1))]
+    vertices_new, entities_new, jx = fixmesh(vertices, entities_new, dim=dim)
+    return vertices_new, entities_new, jx
 
 
 def vertex_to_entities(vertices, entities, dim=2):

--- a/examples/example_2D.py
+++ b/examples/example_2D.py
@@ -33,9 +33,7 @@ def example_2D():
     ef.plot()
 
     # Construct mesh generator
-    mshgen = SeismicMesh.MeshGenerator(
-        ef, method="cgal"
-    )  # if you have cgal installed, you can use method="cgal"
+    mshgen = SeismicMesh.MeshGenerator(ef)
 
     # Build the mesh (note the seed makes the result deterministic)
     points, facets = mshgen.build(max_iter=50, nscreen=1, seed=0)

--- a/examples/example_2D_SDF.py
+++ b/examples/example_2D_SDF.py
@@ -29,9 +29,7 @@ def example_2D_SDF():
         return h
 
     # Construct mesh generator
-    mshgen = SeismicMesh.MeshGenerator(
-        method="cgal", hmin=hmin, bbox=bbox, fd=SDF, fh=EF
-    )
+    mshgen = SeismicMesh.MeshGenerator(hmin=hmin, bbox=bbox, fd=SDF, fh=EF)
 
     # Build the mesh (note the seed makes the result deterministic)
     points, facets = mshgen.build(max_iter=50)

--- a/examples/example_2D_parallel.py
+++ b/examples/example_2D_parallel.py
@@ -41,9 +41,7 @@ def example_2D_parallel():
         # ef.plot()
 
     # Construct mesh generator
-    mshgen = SeismicMesh.MeshGenerator(
-        ef, method="cgal"
-    )  # parallel currently only works in qhull
+    mshgen = SeismicMesh.MeshGenerator(ef)
 
     # Build the mesh (note the seed makes the result deterministic)
     points, facets = mshgen.build(

--- a/examples/example_3D.py
+++ b/examples/example_3D.py
@@ -30,9 +30,7 @@ def example_3D():
     ef.SaveMeshSizeFunctionOptions("EGAGE_Salt")
 
     # Construct mesh generator
-    mshgen = SeismicMesh.MeshGenerator(
-        ef, method="cgal"
-    )  # or qhull but qhull is 5x slower than cgal
+    mshgen = SeismicMesh.MeshGenerator(ef)
 
     # Build the mesh
     points, cells = mshgen.build(nscreen=1, max_iter=30, seed=0)

--- a/examples/example_3D_parallel.py
+++ b/examples/example_3D_parallel.py
@@ -39,7 +39,7 @@ def example_3D_parallel():
         ef.WriteVelocityModel("EGAGE_Salt")
 
     # Construct mesh generator
-    mshgen = SeismicMesh.MeshGenerator(ef, method="cgal")
+    mshgen = SeismicMesh.MeshGenerator(ef)
 
     # Build the mesh (note the seed makes the result deterministic)
     points, cells = mshgen.build(max_iter=75, seed=0, COMM=comm)

--- a/tests/test_2dmesher.py
+++ b/tests/test_2dmesher.py
@@ -17,13 +17,7 @@ def test_2dmesher():
         bbox=(-10e3, 0, 0, 10e3), grade=grade, wl=wl, model=fname, hmin=hmin
     )
     ef = ef.build()
-    mshgen = SeismicMesh.MeshGenerator(ef, method="qhull")
-    points, facets = mshgen.build(max_iter=100, seed=0)
-    # should have: 7690 vertices and 15045 cells
-    assert np.abs(len(points) - 7690) < 20
-    assert np.abs(len(facets) - 15045) < 20
-
-    mshgen = SeismicMesh.MeshGenerator(ef, method="cgal")
+    mshgen = SeismicMesh.MeshGenerator(ef)
     points, facets = mshgen.build(max_iter=100, seed=0)
     # should have: 7690 vertices and 15045 cells
     assert np.abs(len(points) - 7690) < 20

--- a/tests/test_2dmesher_par.py
+++ b/tests/test_2dmesher_par.py
@@ -26,23 +26,8 @@ def test_2dmesher_par():
     # Build lambda functions
     ef = ef.construct_lambdas(comm)
 
-    # test qhull
-    mshgen = SeismicMesh.MeshGenerator(ef, method="qhull")
-    points, cells = mshgen.build(max_iter=100, seed=0, COMM=comm, perform_checks=True)
-    if rank == 0:
-        # import meshio
-
-        # meshio.write_points_cells(
-        #   "test2d.vtk", points / 1000, [("triangle", cells)], file_format="vtk",
-        # )
-        area = SeismicMesh.geometry.simpvol(points / 1000, cells)
-        # 7658 vertices and 14965
-        assert np.abs(100 - np.sum(area)) < 0.50  # km2
-        assert np.abs(7658 - len(points)) < 20
-        assert np.abs(14965 - len(cells)) < 20
-
     # test cgal
-    mshgen = SeismicMesh.MeshGenerator(ef, method="cgal")
+    mshgen = SeismicMesh.MeshGenerator(ef)
     points, cells = mshgen.build(max_iter=100, seed=0, COMM=comm, perform_checks=True)
     if rank == 0:
         # import meshio

--- a/tests/test_3dmesher.py
+++ b/tests/test_3dmesher.py
@@ -31,7 +31,7 @@ def test_3dmesher():
     points, cells = mshgen.build(nscreen=1, max_iter=20, seed=0)
     print(len(points), len(cells))
     assert len(points) == 16459
-    assert np.abs(len(cells) - 96297) < 500
+    assert np.abs(len(cells) - 96297) < 600
 
 
 if __name__ == "__main__":

--- a/tests/test_3dmesher.py
+++ b/tests/test_3dmesher.py
@@ -27,17 +27,11 @@ def test_3dmesher():
         hmin=hmin,
     )
     ef = ef.build()
-    mshgen = SeismicMesh.MeshGenerator(ef, method="cgal")
+    mshgen = SeismicMesh.MeshGenerator(ef)
     points, cells = mshgen.build(nscreen=1, max_iter=20, seed=0)
     print(len(points), len(cells))
     assert len(points) == 16459
-    assert np.abs(len(cells) - 96297) < 150
-
-    mshgen = SeismicMesh.MeshGenerator(ef, method="qhull")
-    points, cells = mshgen.build(nscreen=1, max_iter=20, seed=0)
-    print(len(points), len(cells))
-    assert len(points) == 16459
-    assert np.abs(len(cells) - 97480) < 150
+    assert np.abs(len(cells) - 96297) < 500
 
 
 if __name__ == "__main__":

--- a/tests/test_3dmesher_par.py
+++ b/tests/test_3dmesher_par.py
@@ -37,31 +37,7 @@ def test_3dpar_mesher():
     # Build lambda functions
     ef = ef.construct_lambdas(comm)
 
-    mshgen = SeismicMesh.MeshGenerator(
-        ef, method="qhull"
-    )  # parallel currently only works in qhull
-    points, cells = mshgen.build(max_iter=50, nscreen=1, seed=0, COMM=comm, axis=0,)
-
-    if rank == 0:
-        # remove slivers
-        points, cells = mshgen.build(
-            points=points, max_iter=15, nscreen=1, seed=0, mesh_improvement=True,
-        )
-        # import meshio
-
-        # meshio.write_points_cells(
-        #    "foo3D_V3.vtk", points, [("tetra", cells)],
-        # )
-
-        vol = SeismicMesh.geometry.simpvol(points / 1000, cells)
-        assert np.abs(2 - np.sum(vol)) < 0.10  # km2
-        print(len(points), len(cells))
-        assert np.abs(9220 - len(points)) < 250
-        assert np.abs(49263 - len(cells)) < 250
-
-    mshgen = SeismicMesh.MeshGenerator(
-        ef, method="cgal"
-    )  # parallel currently only works in qhull
+    mshgen = SeismicMesh.MeshGenerator(ef)
 
     points, cells = mshgen.build(max_iter=50, nscreen=1, seed=0, COMM=comm, axis=0,)
 
@@ -80,7 +56,7 @@ def test_3dpar_mesher():
         assert np.abs(2 - np.sum(vol)) < 0.10  # km2
         print(len(points), len(cells))
         assert np.abs(9220 - len(points)) < 250
-        assert np.abs(49263 - len(cells)) < 250
+        assert np.abs(57044 - len(cells)) < 250
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
-Removing all qhull options in lieu of CGAL's vasty more efficient and incremental Delaunay in 2 and 3D via calls to the library using pybind11. 
-Cleaning up mesh generator. 
-Sliver removal now uses incremental moves instead of a full retriangulation when using the perturbation technique. 
-Parallelization uses incremental inserts to add ghost zones. 
-Switching to py.test instead of pytest.py as pytest was including all imported modules in the coverage reports!