### PR TITLE
Accelerating meshgen.build()

### DIFF
--- a/SeismicMesh/generation/utils.py
+++ b/SeismicMesh/generation/utils.py
@@ -80,13 +80,11 @@ def __setdiff_rows(A, B, return_index=False):
         return C
 
 
-def unique_rows(a):
-    # The cleaner alternative `numpy.unique(a, axis=0)` is slow; cf.
-    # <https://github.com/numpy/numpy/issues/11136>.
-    b = np.ascontiguousarray(a).view(np.dtype((np.void, a.dtype.itemsize * a.shape[1])))
-    a_unique, inv, cts = np.unique(b, return_inverse=True, return_counts=True)
-    a_unique = a_unique.view(a.dtype).reshape(-1, a.shape[1])
-    return a_unique, inv, cts
+def unique_rows(ar):
+    ar_row_view = ar.view("|S%d" % (ar.itemsize * ar.shape[1]))
+    _, unique_row_indices = np.unique(ar_row_view, return_index=True)
+    ar_out = ar[unique_row_indices]
+    return ar_out
 
 
 def dense(Ix, J, S, shape=None, dtype=None):

--- a/SeismicMesh/sizing/mesh_size_function.py
+++ b/SeismicMesh/sizing/mesh_size_function.py
@@ -484,9 +484,11 @@ class MeshSizeFunction:
                     self.fd = lambda p: fdd(p)
                 if _dim == 3:
                     self.fd = lambda p: fdd2(p)
+        if size > 1:
+            self._construct_lambdas(comm)
         return self
 
-    def construct_lambdas(self, comm):
+    def _construct_lambdas(self, comm):
         """
         Build lambda fields (for parallel only) for
         SDF and mesh size function

--- a/examples/example_2D_parallel.py
+++ b/examples/example_2D_parallel.py
@@ -32,8 +32,6 @@ def example_2D_parallel():
 
     # Build mesh size function (in parallel)
     ef = ef.build(comm=comm)
-    # Build lambda functions
-    ef = ef.construct_lambdas(comm)
 
     if rank == 0:
         ef.WriteVelocityModel("BP2004_w1KM_EXT")

--- a/examples/example_3D_parallel.py
+++ b/examples/example_3D_parallel.py
@@ -32,8 +32,6 @@ def example_3D_parallel():
 
     # Build mesh size function (in parallel)
     ef = ef.build(comm=comm)
-    # Build lambda functions
-    ef = ef.construct_lambdas(comm)
 
     if rank == 0:
         ef.WriteVelocityModel("EGAGE_Salt")

--- a/examples/example_3D_parallel.py
+++ b/examples/example_3D_parallel.py
@@ -42,7 +42,7 @@ def example_3D_parallel():
     mshgen = SeismicMesh.MeshGenerator(ef)
 
     # Build the mesh (note the seed makes the result deterministic)
-    points, cells = mshgen.build(max_iter=75, seed=0, COMM=comm)
+    points, cells = mshgen.build(max_iter=75, seed=0, COMM=comm, axis=1)
 
     if rank == 0:
 

--- a/tests/test_2dmesher_par.py
+++ b/tests/test_2dmesher_par.py
@@ -23,8 +23,6 @@ def test_2dmesher_par():
         bbox=(-10e3, 0, 0, 10e3), grade=grade, wl=wl, model=fname, hmin=hmin
     )
     ef = ef.build(comm=comm)
-    # Build lambda functions
-    ef = ef.construct_lambdas(comm)
 
     # test cgal
     mshgen = SeismicMesh.MeshGenerator(ef)

--- a/tests/test_3dmesher_par.py
+++ b/tests/test_3dmesher_par.py
@@ -34,8 +34,6 @@ def test_3dpar_mesher():
     )
     # Build mesh size function (in parallel)
     ef = ef.build(comm=comm)
-    # Build lambda functions
-    ef = ef.construct_lambdas(comm)
 
     mshgen = SeismicMesh.MeshGenerator(ef)
 


### PR DESCRIPTION
Using a modified unique operation that converts integers to bytes and then performs the unique on the bytes. About 3x faster than previous method and thus results in a net speed-up by a couple seconds per meshing iteration.