### PR TITLE
adding support for constant cell-size

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,8 @@ How does performance and cell quality compare to `gmsh` and `cgal` mesh generato
 
 ![Summary of the benchmarks.](https://user-images.githubusercontent.com/18619644/95405635-beb98500-08ee-11eb-97a4-5bb7e3c20305.png)
 
+* **In the figure above, solid lines indicate mean cell qualities while dashed line indicate minimum cell qualities in the mesh**
+
 * Note: it's important to point out here that a significant speed-up can be achieved for moderate to large problems using the [parallel capabilities](https://seismicmesh.readthedocs.io/en/par3d/tutorial.html#basics) provided in `SeismicMesh`.
 
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ if comm.rank == 0:
 seismic velocity model from (WARNING: File is \~500 MB)**
 [here](https://s3.amazonaws.com/open.source.geoscience/open_data/seg_eage_models_cd/Salt_Model_3D.tar.gz)
 
-**WARNING: Computationaly demanding! Running this example takes around 5 minutes in serial and requires
+**WARNING: Computationaly demanding! Running this example takes around 3 minutes in serial and requires
 around 2 GB of RAM due to the 3D nature of the problem and the domain
 size.**
 
@@ -314,8 +314,8 @@ How does performance and cell quality compare to `gmsh` and `cgal` mesh generato
 ===================================================================================
 
 * Mesh generation in 2D and 3D using analytical sizing functions is quickest when using `gmsh` followed by `cgal` and then `SeismicMesh`.
-* However, using mesh sizing functions defined on gridded interpolants significantly slow down both `gmsh` and `cgal`. In this case, `SeismicMesh` and `gmsh` perform similarly and both outperform `cgal`.
-* `SeismicMesh` produces consistently higher mean cell qualities in 2D/3D than either `gmsh` or `cgal`.
+* However, using mesh sizing functions defined on gridded interpolants significantly slow down both `gmsh` and `cgal`. In these cases, `SeismicMesh` and `gmsh` perform similarly both outperforming `cgal`'s 3D mesh generator in terms of mesh generation time.
+* `SeismicMesh` produces consistently higher mean cell qualities in 2D/3D than either `gmsh` or `cgal` and this may have implications on mesh improvement strategies as higher minimum quality may be realizable with some common mesh improvement strategies (e.g., NetGen)
 * All methods produce 3D triangulations that have a minimum dihedral angle > 10 degrees enabling stable numerical simulation.
 * Head over to the `benchmarks` folder for more detailed information on these experiments.
 

--- a/README.md
+++ b/README.md
@@ -292,14 +292,15 @@ meshio.write_points_cells(
 )
 ```
 
-![cube](https://user-images.githubusercontent.com/18619644/95607827-a94d7380-0a32-11eb-9601-7677edd2febb.png)
+![cube](https://user-images.githubusercontent.com/18619644/95621214-b3c63800-0a47-11eb-9600-a80ef2410334.png)
+
 
 ```python
 import SeismicMesh
 import meshio
 
 cube = SeismicMesh.Cube((0.0, 1.0, 0.0, 1.0, 0.0, 1.0))
-points, cells = SeismicMesh.generate_mesh(domain=cube, cell_size=0.1)
+points, cells = SeismicMesh.generate_mesh(domain=cube, cell_size=0.05)
 meshio.write_points_cells(
     "cube.vtk",
     points,

--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ For more detailed information about installation and requirements see:
 [Install](https://seismicmesh.readthedocs.io/en/par3d/install.html) -
 How to install SeismicMesh.
 
-Example
-=======
+Examples
+========
 
 The user can quickly build quality 2D/3D meshes from seismic velocity
 models in serial/parallel.
@@ -175,7 +175,7 @@ ef = get_sizing_function_from_segy(
     nz=nz,
     nx=nx,
     ny=ny,
-    byte_order="big"
+    byte_order="big",
 )
 
 points, cells = generate_mesh(domain=cube, h0=hmin, cell_size=ef, max_iter=75)
@@ -197,11 +197,12 @@ if comm.rank == 0:
     )
 ```
 
-**The user can still specify their own signed distance functions and sizing functions to `generate_mesh` (in serial or parallel) just like the original DistMesh algorithm. Try the code below!**
+**The user can still specify their own signed distance functions and sizing functions to `generate_mesh` (in serial or parallel) just like the original DistMesh algorithm. Try the codes below!**
 
 ![Above shows the mesh in ParaView that results from running the code below.](https://user-images.githubusercontent.com/18619644/93465337-05542a80-f8c1-11ea-8774-a059e215088f.png)
 
 ```python
+# Mesh a unit cylinder
 from mpi4py import MPI
 from numpy import array, maximum, sqrt, zeros_like
 import meshio
@@ -210,7 +211,6 @@ from SeismicMesh import generate_mesh, sliver_removal
 
 comm = MPI.COMM_WORLD
 
-"""Mesh a unit cylinder"""
 
 hmin = 0.10
 bbox = (-1.0, 1.0, -1.0, 1.0, -1.0, 1.0)
@@ -260,18 +260,15 @@ if comm.rank == 0:
     )
 ```
 
-**A disk, a cube and a rectangle geometries can be quickly meshed too.**
-
 ![Disk](https://user-images.githubusercontent.com/18619644/95608173-1f51da80-0a33-11eb-90be-170beda85b5a.png)
 
 ```python
 import SeismicMesh
 import meshio
 
-disk = SeismicMesh.disk(0.0, 0.0, 1.0)
+disk = SeismicMesh.Disk(0.0, 0.0, 1.0)
 points, cells = SeismicMesh.generate_mesh(domain=disk, cell_size=0.1)
-meshio.write_p
-oints_cells(
+meshio.write_points_cells(
     "disk.vtk",
     points,
     [("triangle", cells)],
@@ -279,8 +276,8 @@ oints_cells(
 )
 ```
 
-
 ![Rect](https://user-images.githubusercontent.com/18619644/95607603-5d023380-0a32-11eb-9c6f-41fac9e00aa7.png)
+
 ```python
 import SeismicMesh
 import meshio
@@ -296,19 +293,20 @@ meshio.write_points_cells(
 ```
 
 ![cube](https://user-images.githubusercontent.com/18619644/95607827-a94d7380-0a32-11eb-9601-7677edd2febb.png)
-```python
- import SeismicMesh
- import meshio
 
- cube = SeismicMesh.Cube((0.0, 1.0, 0.0, 1.0, 0.0, 1.0))
- points, cells = SeismicMesh.generate_mesh(domain=cube, cell_size=0.1)
- meshio.write_points_cells(
-     "cube.vtk",
-     points,
-     [("tetra", cells)],
-     file_format="vtk",
- )
- ```
+```python
+import SeismicMesh
+import meshio
+
+cube = SeismicMesh.Cube((0.0, 1.0, 0.0, 1.0, 0.0, 1.0))
+points, cells = SeismicMesh.generate_mesh(domain=cube, cell_size=0.1)
+meshio.write_points_cells(
+    "cube.vtk",
+    points,
+    [("tetra", cells)],
+    file_format="vtk",
+)
+```
 
 How does performance and cell quality compare to `gmsh` and `cgal` mesh generators?
 ===================================================================================

--- a/README.md
+++ b/README.md
@@ -260,8 +260,58 @@ if comm.rank == 0:
     )
 ```
 
-How does it compare to `gmsh` and `cgal` mesh generators?
-=========================================================
+** A disk, a cube and a rectangle geometries can be quickly meshed.
+
+![Disk](https://user-images.githubusercontent.com/18619644/95608173-1f51da80-0a33-11eb-90be-170beda85b5a.png)
+
+```python
+import SeismicMesh
+import meshio
+
+disk = SeismicMesh.disk(0.0, 0.0, 1.0)
+points, cells = SeismicMesh.generate_mesh(domain=disk, cell_size=0.1)
+meshio.write_p
+oints_cells(
+    "disk.vtk",
+    points,
+    [("triangle", cells)],
+    file_format="vtk",
+)
+```
+
+
+![Rect](https://user-images.githubusercontent.com/18619644/95607603-5d023380-0a32-11eb-9c6f-41fac9e00aa7.png)
+```python
+import SeismicMesh
+import meshio
+
+rect = SeismicMesh.Rectangle((0.0, 1.0, 0.0, 1.0))
+points, cells = SeismicMesh.generate_mesh(domain=rect, cell_size=0.1)
+meshio.write_points_cells(
+    "rectangle.vtk",
+    points,
+    [("triangle", cells)],
+    file_format="vtk",
+)
+```
+
+![cube](https://user-images.githubusercontent.com/18619644/95607827-a94d7380-0a32-11eb-9601-7677edd2febb.png)
+```python
+ import SeismicMesh
+ import meshio
+
+ cube = SeismicMesh.Cube((0.0, 1.0, 0.0, 1.0, 0.0, 1.0))
+ points, cells = SeismicMesh.generate_mesh(domain=cube, cell_size=0.1)
+ meshio.write_points_cells(
+     "cube.vtk",
+     points,
+     [("tetra", cells)],
+     file_format="vtk",
+ )
+ ```
+
+How does performance and cell quality compare to `gmsh` and `cgal` mesh generators?
+===================================================================================
 
 * Mesh generation in 2D and 3D using analytical sizing functions is quickest when using `gmsh` followed by `cgal` and then `SeismicMesh`.
 * However, using mesh sizing functions defined on gridded interpolants significantly slow down both `gmsh` and `cgal`. In this case, `SeismicMesh` and `gmsh` perform similarly and both outperform `cgal`.

--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ if comm.rank == 0:
     )
 ```
 
-** A disk, a cube and a rectangle geometries can be quickly meshed.
+**A disk, a cube and a rectangle geometries can be quickly meshed too.**
 
 ![Disk](https://user-images.githubusercontent.com/18619644/95608173-1f51da80-0a33-11eb-90be-170beda85b5a.png)
 

--- a/SeismicMesh/generation/mesh_generator.py
+++ b/SeismicMesh/generation/mesh_generator.py
@@ -629,13 +629,14 @@ def _generate_initial_points(h0, geps, dim, bbox, fh, fd, pfix, comm, opts):
         p = mutils.make_init_points(bbox, comm.rank, comm.size, opts["axis"], h0, dim)
     else:
         # Create initial distribution in bounding box (equilateral triangles)
-        if dim == 2:
-            p = mutils.create_staggered_grid_2d(h0, bbox)
-        elif dim == 3:
-            p = np.mgrid[tuple(slice(min, max + h0, h0) for min, max in bbox)].astype(
-                float
-            )
-            p = p.reshape(dim, -1).T
+        p = mutils.create_staggered_grid(h0, dim, bbox)
+        # if dim == 2:
+        #    p = mutils.create_staggered_grid(h0, dim, bbox)
+        # elif dim == 3:
+        #    p = np.mgrid[tuple(slice(min, max + h0, h0) for min, max in bbox)].astype(
+        #        float
+        #    )
+        #    p = p.reshape(dim, -1).T
 
     # Remove points outside the region, apply the rejection method
     p = p[fd(p) < geps]  # Keep only d<0 points

--- a/SeismicMesh/generation/mesh_generator.py
+++ b/SeismicMesh/generation/mesh_generator.py
@@ -106,7 +106,7 @@ def sliver_removal(points, domain, cell_size, comm=None, **kwargs):
         bbox = _minmax(bbox0, bbox1)
 
     # rebuild the Rectangle or Cube if domain padding
-    if bbox0 != bbox1:
+    if bbox0 != bbox1 and bbox1 is not None:
         fd = geometry.Cube(bbox).eval
 
     if not isinstance(bbox, tuple):
@@ -316,7 +316,7 @@ def generate_mesh(domain, cell_size, comm=None, **kwargs):
     dim = int(len(bbox) / 2)
 
     # rebuild the Rectangle or Cube if domain padding
-    if bbox0 != bbox1:
+    if bbox0 != bbox1 and bbox1 is not None:
         if dim == 2:
             tmp = geometry.Rectangle(bbox)
         elif dim == 3:

--- a/SeismicMesh/generation/mesh_generator.py
+++ b/SeismicMesh/generation/mesh_generator.py
@@ -437,7 +437,11 @@ def _unpack_sizing(cell_size):
     elif np.isscalar(cell_size):
 
         def func(x):
-            return np.array([cell_size] * len(x))
+            if type(x) == tuple:
+                h = np.zeros_like(x[0]) + cell_size
+            else:
+                h = np.array([cell_size] * len(x))
+            return h
 
         fh = func
         hmin = cell_size
@@ -630,13 +634,6 @@ def _generate_initial_points(h0, geps, dim, bbox, fh, fd, pfix, comm, opts):
     else:
         # Create initial distribution in bounding box (equilateral triangles)
         p = mutils.create_staggered_grid(h0, dim, bbox)
-        # if dim == 2:
-        #    p = mutils.create_staggered_grid(h0, dim, bbox)
-        # elif dim == 3:
-        #    p = np.mgrid[tuple(slice(min, max + h0, h0) for min, max in bbox)].astype(
-        #        float
-        #    )
-        #    p = p.reshape(dim, -1).T
 
     # Remove points outside the region, apply the rejection method
     p = p[fd(p) < geps]  # Keep only d<0 points

--- a/SeismicMesh/generation/utils.py
+++ b/SeismicMesh/generation/utils.py
@@ -25,50 +25,6 @@ def create_staggered_grid(h0, dim, bbox):
     return points
 
 
-# def create_staggered_grid_2d(h, bounding_box):
-#    """https://github.com/nschloe/dmsh/blob/master/dmsh/main.py"""
-#    bounding_box = bounding_box.flatten()
-#    x_step = h
-#    y_step = h * np.sqrt(3) / 2
-#    bb_width = bounding_box[1] - bounding_box[0]
-#    bb_height = bounding_box[3] - bounding_box[2]
-#    midpoint = [
-#        (bounding_box[0] + bounding_box[1]) / 2,
-#        (bounding_box[2] + bounding_box[3]) / 2,
-#    ]
-#
-#    num_x_steps = int(bb_width / x_step)
-#    if num_x_steps % 2 == 1:
-#        num_x_steps -= 1
-#    num_y_steps = int(bb_height / y_step)
-#    if num_y_steps % 2 == 1:
-#        num_y_steps -= 1
-#
-#    # Generate initial (staggered) point list from bounding box.
-#    # Make sure that the midpoint is one point in the grid.
-#    x2 = num_x_steps // 2
-#    y2 = num_y_steps // 2
-#    x, y = np.meshgrid(
-#        midpoint[0] + x_step * np.arange(-x2, x2 + 1),
-#        midpoint[1] + y_step * np.arange(-y2, y2 + 1),
-#    )
-#    # Staggered, such that the midpoint is not moved.
-#    # Unconditionally move to the right, then add more points to the left.
-#    offset = (y2 + 1) % 2
-#    x[offset::2] += h / 2
-#
-#    out = np.column_stack([x.reshape(-1), y.reshape(-1)])
-#
-#    # add points in the staggered lines to preserve symmetry
-#    n = 2 * (-(-y2 // 2))
-#    extra = np.empty((n, 2))
-#    extra[:, 0] = midpoint[0] - x_step * x2 - h / 2
-#    extra[:, 1] = midpoint[1] + y_step * np.arange(-y2 + offset, y2 + 1, 2)
-#
-#    out = np.concatenate([out, extra])
-#    return out
-
-
 def make_init_points(bbox, rank, size, axis, h0, dim):
     """Create a structured grid in parallel of the entire domain
     Each processor owns a part of the domain.
@@ -85,10 +41,7 @@ def make_init_points(bbox, rank, size, axis, h0, dim):
                 tmp = np.mgrid[slice(prev_lims[0], prev_lims[1] + h0, h0)]
                 _bbox[i, 0] = tmp[-1] + h0
 
-    points = np.mgrid[tuple(slice(min, max + h0, h0) for min, max in _bbox)].astype(
-        float
-    )
-    points = points.reshape(dim, -1).T
+    points = create_staggered_grid(h0, dim, _bbox)
     return points
 
 

--- a/SeismicMesh/generation/utils.py
+++ b/SeismicMesh/generation/utils.py
@@ -4,48 +4,69 @@ import numpy as np
 import scipy.sparse as spsparse
 
 
-def create_staggered_grid_2d(h, bounding_box):
-    """https://github.com/nschloe/dmsh/blob/master/dmsh/main.py"""
-    bounding_box = bounding_box.flatten()
-    x_step = h
-    y_step = h * np.sqrt(3) / 2
-    bb_width = bounding_box[1] - bounding_box[0]
-    bb_height = bounding_box[3] - bounding_box[2]
-    midpoint = [
-        (bounding_box[0] + bounding_box[1]) / 2,
-        (bounding_box[2] + bounding_box[3]) / 2,
-    ]
+def odd(r):
+    odds = []
+    for i in range(r):
+        if i % 2 != 0:
+            odds.append(i)
+    return odds
 
-    num_x_steps = int(bb_width / x_step)
-    if num_x_steps % 2 == 1:
-        num_x_steps -= 1
-    num_y_steps = int(bb_height / y_step)
-    if num_y_steps % 2 == 1:
-        num_y_steps -= 1
 
-    # Generate initial (staggered) point list from bounding box.
-    # Make sure that the midpoint is one point in the grid.
-    x2 = num_x_steps // 2
-    y2 = num_y_steps // 2
-    x, y = np.meshgrid(
-        midpoint[0] + x_step * np.arange(-x2, x2 + 1),
-        midpoint[1] + y_step * np.arange(-y2, y2 + 1),
+def create_staggered_grid(h0, dim, bbox):
+    points = np.mgrid[tuple(slice(min, max + h0, h0) for min, max in bbox)].astype(
+        float
     )
-    # Staggered, such that the midpoint is not moved.
-    # Unconditionally move to the right, then add more points to the left.
-    offset = (y2 + 1) % 2
-    x[offset::2] += h / 2
+    odds_rows = odd(points[0].shape[0])
+    odds_cols = odd(points[1].shape[0])
+    points[1][odds_rows] += h0 / 2
+    if dim == 3:
+        points[2][odds_cols] += h0 / 2
+    points = points.reshape(dim, -1).T
+    return points
 
-    out = np.column_stack([x.reshape(-1), y.reshape(-1)])
 
-    # add points in the staggered lines to preserve symmetry
-    n = 2 * (-(-y2 // 2))
-    extra = np.empty((n, 2))
-    extra[:, 0] = midpoint[0] - x_step * x2 - h / 2
-    extra[:, 1] = midpoint[1] + y_step * np.arange(-y2 + offset, y2 + 1, 2)
-
-    out = np.concatenate([out, extra])
-    return out
+# def create_staggered_grid_2d(h, bounding_box):
+#    """https://github.com/nschloe/dmsh/blob/master/dmsh/main.py"""
+#    bounding_box = bounding_box.flatten()
+#    x_step = h
+#    y_step = h * np.sqrt(3) / 2
+#    bb_width = bounding_box[1] - bounding_box[0]
+#    bb_height = bounding_box[3] - bounding_box[2]
+#    midpoint = [
+#        (bounding_box[0] + bounding_box[1]) / 2,
+#        (bounding_box[2] + bounding_box[3]) / 2,
+#    ]
+#
+#    num_x_steps = int(bb_width / x_step)
+#    if num_x_steps % 2 == 1:
+#        num_x_steps -= 1
+#    num_y_steps = int(bb_height / y_step)
+#    if num_y_steps % 2 == 1:
+#        num_y_steps -= 1
+#
+#    # Generate initial (staggered) point list from bounding box.
+#    # Make sure that the midpoint is one point in the grid.
+#    x2 = num_x_steps // 2
+#    y2 = num_y_steps // 2
+#    x, y = np.meshgrid(
+#        midpoint[0] + x_step * np.arange(-x2, x2 + 1),
+#        midpoint[1] + y_step * np.arange(-y2, y2 + 1),
+#    )
+#    # Staggered, such that the midpoint is not moved.
+#    # Unconditionally move to the right, then add more points to the left.
+#    offset = (y2 + 1) % 2
+#    x[offset::2] += h / 2
+#
+#    out = np.column_stack([x.reshape(-1), y.reshape(-1)])
+#
+#    # add points in the staggered lines to preserve symmetry
+#    n = 2 * (-(-y2 // 2))
+#    extra = np.empty((n, 2))
+#    extra[:, 0] = midpoint[0] - x_step * x2 - h / 2
+#    extra[:, 1] = midpoint[1] + y_step * np.arange(-y2 + offset, y2 + 1, 2)
+#
+#    out = np.concatenate([out, extra])
+#    return out
 
 
 def make_init_points(bbox, rank, size, axis, h0, dim):

--- a/tests/test_2dmesher.py
+++ b/tests/test_2dmesher.py
@@ -40,7 +40,7 @@ def test_2dmesher():
     points, cells = generate_mesh(
         rectangle,
         ef,
-        hmin,
+        h0=hmin,
         perform_checks=True,
     )
     # should have: 7690 vertices and 15045 cells

--- a/tests/test_2dmesher_domain_extension.py
+++ b/tests/test_2dmesher_domain_extension.py
@@ -16,9 +16,9 @@ from SeismicMesh import (
 @pytest.mark.parametrize(
     "style_answer",
     (
-        ("linear_ramp", [10789, 21219]),
-        ("edge", [11106, 21814]),
-        ("constant", [10789, 21219]),
+        ("linear_ramp", [9428, 18525]),
+        ("edge", [9724, 19078]),
+        ("constant", [9428, 18525]),
     ),
 )
 def test_2dmesher_domain_extension(style_answer):

--- a/tests/test_2dmesher_domain_extension.py
+++ b/tests/test_2dmesher_domain_extension.py
@@ -50,7 +50,7 @@ def test_2dmesher_domain_extension(style_answer):
     points, cells = generate_mesh(
         rectangle,
         ef,
-        hmin,
+        h0=hmin,
         perform_checks=True,
     )
     # import meshio

--- a/tests/test_2dmesher_par.py
+++ b/tests/test_2dmesher_par.py
@@ -32,7 +32,7 @@ def test_2dmesher_par():
     points, cells = generate_mesh(
         rectangle,
         ef,
-        hmin,
+        h0=hmin,
         max_iter=100,
         perform_checks=False,
     )

--- a/tests/test_3dmesher_par.py
+++ b/tests/test_3dmesher_par.py
@@ -69,8 +69,8 @@ def test_3dmesher_par():
         vol = geometry.simp_vol(points / 1000, cells)
         assert np.abs(2 - np.sum(vol)) < 0.10  # km2
         print(len(points), len(cells))
-        assert np.abs(9220 - len(points)) < 1000
-        assert np.abs(49156 - len(cells)) < 1000
+        assert np.abs(9220 - len(points)) < 5000
+        assert np.abs(49156 - len(cells)) < 5000
 
 
 if __name__ == "__main__":

--- a/tests/test_3dmesher_par_adapt.py
+++ b/tests/test_3dmesher_par_adapt.py
@@ -35,7 +35,7 @@ def test_3dmesher_par_adapt():
     points, cells = generate_mesh(
         cube,
         ef,
-        hmin,
+        h0=hmin,
         max_iter=10,
         perform_checks=False,
     )

--- a/tests/test_README.py
+++ b/tests/test_README.py
@@ -12,7 +12,7 @@ this_dir = pathlib.Path(__file__).resolve().parent
 @pytest.mark.serial
 @pytest.mark.parametrize(
     "string,lineno",
-    exdown.extract(this_dir.parent / "README.md", syntax_filter="python"),
+    exdown.extract(this_dir.parent / "README.md", syntax_filter="python", max_num_lines=100000),
 )
 def test_readme(string, lineno):
 

--- a/tests/test_README.py
+++ b/tests/test_README.py
@@ -12,7 +12,9 @@ this_dir = pathlib.Path(__file__).resolve().parent
 @pytest.mark.serial
 @pytest.mark.parametrize(
     "string,lineno",
-    exdown.extract(this_dir.parent / "README.md", syntax_filter="python", max_num_lines=100000),
+    exdown.extract(
+        this_dir.parent / "README.md", syntax_filter="python", max_num_lines=100000
+    ),
 )
 def test_readme(string, lineno):
 


### PR DESCRIPTION
* Addresses #69 

* Enables simple constant resolution meshes to built (e.g., disk, cuboids, and rectangles) : 

* `h0` becomes a kwarg argument but is required for variable meshes with variable cell-sizes. 
```
import SeismicMesh
 
disk = SeismicMesh.Disk(0.0, 0.0, 1.0)
points, cells = SeismicMesh.generate_mesh(domain=disk, cell_size=0.1)
```
producing this: 
```
python disk.py 
Commencing mesh generation with 471 vertices on rank 0.
Termination reached...maximum number of iterations reached.
```