### PR TITLE
ensure bbox is all floats

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Takes roughly 1 minute with 2 processors and less than 1 GB of RAM.
 fname = "vel_z6.25m_x12.5m_exact.segy"
 
 # Bounding box describing domain extents (corner coordinates)
-bbox = (-12000, 0.0, 0.0, 67000.0)
+bbox = (-12000.0, 0.0, 0.0, 67000.0)
 
 # Desired minimum mesh size in domain
 hmin = 75.0
@@ -139,7 +139,7 @@ from SeismicMesh import (
 comm = MPI.COMM_WORLD
 
 # Bounding box describing domain extents (corner coordinates)
-bbox = (-4200, 0, 0, 13520, 0, 13520)
+bbox = (-4200.0, 0.0, 0.0, 13520.0, 0.0, 13520.0)
 
 # Desired minimum mesh size in domain.
 hmin = 150.0
@@ -338,19 +338,20 @@ Changelog
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project (tries to) adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-Unreleased 
+Unreleased
 ==========
 
 ### Fixed
-- Units in km-s detection warning bug. 
+- Units in km-s detection warning bug.
 - Docstring fixes to `generate_mesh`
 
 ### Added
-- More support for reading binary files packed in a binary format. 
+- More support for reading binary files packed in a binary format.
+- Check to make sure bbox is composed of all floats.
 
 ### [3.0.4] - 2020-10-12
 
-- Improve conformity of level-set in final mesh through additional set of Newton boundary projection iterations. 
+- Improve conformity of level-set in final mesh through additional set of Newton boundary projection iterations.
 
 
 More information

--- a/SeismicMesh/generation/mesh_generator.py
+++ b/SeismicMesh/generation/mesh_generator.py
@@ -480,6 +480,12 @@ def _minmax(bbox0, bbox1):
     return tuple(d)
 
 
+def _check_bbox(bbox):
+    for b in bbox:
+        if isinstance(b, int):
+            raise ValueError("bbox must contain all floats")
+
+
 def _unpack_sizing(edge_length):
     bbox = None
     hmin = None
@@ -503,6 +509,7 @@ def _unpack_sizing(edge_length):
         raise ValueError(
             "`edge_length` must either be a function, a `edge_length` object, or a scalar"
         )
+    _check_bbox(bbox)
     return fh, bbox, hmin
 
 
@@ -522,6 +529,7 @@ def _unpack_domain(domain):
         fd = domain
     else:
         raise ValueError("`domain` must be a function or a :class:`geometry` object")
+    _check_bbox(bbox)
     return fd, bbox
 
 

--- a/SeismicMesh/generation/mesh_generator.py
+++ b/SeismicMesh/generation/mesh_generator.py
@@ -481,9 +481,10 @@ def _minmax(bbox0, bbox1):
 
 
 def _check_bbox(bbox):
-    for b in bbox:
-        if isinstance(b, int):
-            raise ValueError("bbox must contain all floats")
+    if bbox is not None:
+        for b in bbox:
+            if isinstance(b, int):
+                raise ValueError("bbox must contain all floats")
 
 
 def _unpack_sizing(edge_length):

--- a/benchmarks/benchmark_BP2004.py
+++ b/benchmarks/benchmark_BP2004.py
@@ -26,7 +26,7 @@ def _build_sizing(FREQ=2.0, HMIN=75.0):
     fname = "vel_z6.25m_x12.5m_exact.segy"
 
     # Bounding box describing domain extents (corner coordinates)
-    bbox = (-12000, 0.0, 0.0, 67000.0)
+    bbox = (-12000.0, 0.0, 0.0, 67000.0)
 
     # Construct mesh sizing object from velocity model
     ef = get_sizing_function_from_segy(

--- a/benchmarks/benchmark_EAGE.py
+++ b/benchmarks/benchmark_EAGE.py
@@ -22,7 +22,7 @@ from SeismicMesh import (
 from helpers import print_stats_3d
 
 # Bounding box describing domain extents (corner coordinates)
-bbox = (-4200, 0, 0, 13520, 0, 13520)
+bbox = (-4200.0, 0.0, 0.0, 13520.0, 0.0, 13520.0)
 
 
 def _build_sizing(HMIN=150.0, FREQ=2):

--- a/tests/test_2dmesher.py
+++ b/tests/test_2dmesher.py
@@ -16,7 +16,7 @@ from SeismicMesh import (
 def test_2dmesher():
 
     fname = os.path.join(os.path.dirname(__file__), "testing.segy")
-    bbox = (-10e3, 0.0, 0.0, 10e3)
+    bbox = (-10000.0, 0.0, 0.0, 10000.0)
     wl = 5
     freq = 5.0
     hmin = 100

--- a/tests/test_2dmesher_SDF.py
+++ b/tests/test_2dmesher_SDF.py
@@ -10,7 +10,7 @@ def test_2dmesher_SDF():
     hmin = 0.2
     bbox = (-1.0, 1.0, -1.0, 1.0)
 
-    disk = geometry.Disk([0, 0], 1)
+    disk = geometry.Disk([0.0, 0.0], 1)
 
     def EF(p):
         d = disk.eval(p)

--- a/tests/test_3dmesher.py
+++ b/tests/test_3dmesher.py
@@ -21,7 +21,7 @@ def test_3dmesher():
     freq = 2
     hmin = 50
     grade = 0.005
-    bbox = (-2e3, 0.0, 0.0, 1e3, 0, 1e3)
+    bbox = (-2e3, 0.0, 0.0, 1e3, 0.0, 1e3)
     cube = Cube(bbox)
     ef = get_sizing_function_from_segy(
         fname,

--- a/tests/test_3dmesher_domain_extension.py
+++ b/tests/test_3dmesher_domain_extension.py
@@ -28,7 +28,7 @@ def test_3dmesher_domain_extension(style_answer):
     freq = 2
     hmin = 150
     grade = 0.005
-    bbox = (-2e3, 0.0, 0.0, 1e3, 0, 1e3)
+    bbox = (-2e3, 0.0, 0.0, 1e3, 0.0, 1e3)
     cube = Cube(bbox)
     ef = get_sizing_function_from_segy(
         fname,


### PR DESCRIPTION
* If tuple `bbox` contains both integers and floats by chance, this can create problems with the domain decomposition approach used. 
* Now, the program will raise an error if the bbox tuple is not composed of all floats. 