### PR TITLE
preserving pfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,10 +342,13 @@ Unreleased
 ==========
 
 ### Fixed
+- Preserving fixed points in serial.
 - Units in km-s detection warning bug.
 - Docstring fixes to `generate_mesh`
 
 ### Added
+- More accurate 3d cube signed distance function
+- Automatic corner point extraction for cubes and rectangles.
 - More support for reading binary files packed in a binary format.
 - Check to make sure bbox is composed of all floats.
 

--- a/SeismicMesh/generation/mesh_generator.py
+++ b/SeismicMesh/generation/mesh_generator.py
@@ -419,8 +419,8 @@ def generate_mesh(domain, edge_length, comm=None, **kwargs):  # noqa: C901
         p, t = _get_topology(dt)
 
         # Find where pfix went
+        ifix = []
         if nfix > 0:
-            ifix = []
             for fix in pfix:
                 ifix.append(_closest_node(fix, p))
 

--- a/SeismicMesh/generation/mesh_generator.py
+++ b/SeismicMesh/generation/mesh_generator.py
@@ -195,7 +195,7 @@ def sliver_removal(points, domain, edge_length, comm=None, **kwargs):  # noqa: C
 
     count = 0
     pold = None
-
+    push = 0.10
     while True:
 
         start = time.time()
@@ -262,7 +262,7 @@ def sliver_removal(points, domain, edge_length, comm=None, **kwargs):  # noqa: C
             perturb /= perturb_norm[:, None]
 
             # perturb % of local mesh size
-            p[move] += 0.10 * h0 * perturb
+            p[move] += push * h0 * perturb
 
         # Bring outside points back to the boundary
         p = _project_points_back_newton(p, fd, deps)
@@ -418,6 +418,12 @@ def generate_mesh(domain, edge_length, comm=None, **kwargs):  # noqa: C901
         # Get the current topology of the triangulation
         p, t = _get_topology(dt)
 
+        # Find where pfix went
+        if nfix > 0:
+            ifix = []
+            for fix in pfix:
+                ifix.append(_closest_node(fix, p))
+
         # Add ghost points to perform Delaunay in parallel.
         if comm.size > 1:
             p, t, inv, recv_ix = _add_ghost_vertices(p, t, dt, extents, comm)
@@ -439,7 +445,7 @@ def generate_mesh(domain, edge_length, comm=None, **kwargs):  # noqa: C901
         # Compute the forces on the edges
         Ftot = _compute_forces(p, t, fh, h0, L0mult)
 
-        Ftot[:nfix] = 0  # Force = 0 at fixed points
+        Ftot[ifix] = 0  # Force = 0 at fixed points
 
         # Update positions
         p += delta_t * Ftot
@@ -792,3 +798,10 @@ def _get_topology(dt):
     p = dt.get_finite_vertices()
     t = dt.get_finite_cells()
     return p, t
+
+
+def _closest_node(node, nodes):
+    nodes = np.asarray(nodes)
+    deltas = nodes - node
+    dist_2 = np.einsum("ij,ij->i", deltas, deltas)
+    return np.argmin(dist_2)

--- a/SeismicMesh/geometry/__init__.py
+++ b/SeismicMesh/geometry/__init__.py
@@ -28,6 +28,7 @@ from .utils import (
     unique_rows,
     vertex_to_entities,
     vertex_in_entity3,
+    corners,
 )
 
 __all__ = [
@@ -36,6 +37,7 @@ __all__ = [
     "calc_circumsphere_grad",
     "calc_3x3determinant",
     "calc_4x4determinant",
+    "corners",
     "Rectangle",
     "Cube",
     "Disk",

--- a/SeismicMesh/geometry/signed_distance_functions.py
+++ b/SeismicMesh/geometry/signed_distance_functions.py
@@ -54,6 +54,40 @@ def drectangle(p, x1, x2, y1, y2):
 
 
 def dblock(p, x1, x2, y1, y2, z1, z2):
+    # adapted from:
+    # https://github.com/nschloe/dmsh/blob/3305c417d373d509c78491b24e77409411aa18c2/dmsh/geometry/rectangle.py#L31
+    # outside dist
+    # https://gamedev.stackexchange.com/a/44496
+    w = x2 - x1
+    h = y2 - y1
+    d = z2 - z1
+    cx = (x1 + x2) / 2
+    cy = (y1 + y2) / 2
+    cz = (z1 + z2) / 2
+    dx = np.abs(p[:, 0] - cx) - w / 2
+    dy = np.abs(p[:, 1] - cy) - h / 2
+    dz = np.abs(p[:, 2] - cz) - d / 2
+    is_inside = (dx <= 0) & (dy <= 0) & (dz <= 0)
+    dx[dx < 0.0] = 0.0
+    dy[dy < 0.0] = 0.0
+    dz[dz < 0.0] = 0.0
+    dist = np.sqrt(dx ** 2 + dy ** 2 + dz ** 2)
+    # inside dist
+    a = np.array(
+        [
+            p[is_inside, 0] - x1,
+            x2 - p[is_inside, 0],
+            p[is_inside, 1] - y1,
+            y2 - p[is_inside, 1],
+            p[is_inside, 2] - z1,
+            z2 - p[is_inside, 2],
+        ]
+    )
+    dist[is_inside] = -np.min(a, axis=0)
+    return dist
+
+
+def dblock0(p, x1, x2, y1, y2, z1, z2):
     min = np.minimum
     return -min(
         min(

--- a/SeismicMesh/geometry/utils.py
+++ b/SeismicMesh/geometry/utils.py
@@ -1,3 +1,4 @@
+import itertools
 import numpy as np
 import scipy.sparse as spsparse
 
@@ -7,6 +8,13 @@ from .cpp import fast_geometry as gutils
 
 # cpp implementation of 4x4 determinant calc
 dete = gutils.calc_4x4determinant
+
+
+def corners(bbox):
+    """Get the corners of a box in N-dim"""
+    mins = bbox[::2]
+    maxs = bbox[1::2]
+    return list(itertools.product(*zip(mins, maxs)))
 
 
 def calc_re_ratios(vertices, entities, dim=2):

--- a/tests/test_pfix.py
+++ b/tests/test_pfix.py
@@ -1,0 +1,29 @@
+import numpy as np
+import SeismicMesh
+
+
+def test_pfix():
+    hmin = 0.05
+    bbox = (0.0, 1.0, 0.0, 1.0, 0.0, 1.0)
+
+    pfix = np.linspace((0.0, 0.0, 0.0), (1.0, 0.0, 1.0), int(np.sqrt(2) / hmin))
+
+    pfix = np.vstack((pfix, SeismicMesh.geometry.corners(bbox)))
+
+    cube = SeismicMesh.Cube(bbox)
+
+    points, cells = SeismicMesh.generate_mesh(domain=cube, edge_length=hmin, pfix=pfix)
+
+    def _closest_node(node, nodes):
+        nodes = np.asarray(nodes)
+        deltas = nodes - node
+        dist_2 = np.einsum("ij,ij->i", deltas, deltas)
+        return dist_2
+
+    for p in pfix:
+        d = _closest_node(p, points)
+        assert np.isclose(np.min(d), 0.0)
+
+
+if __name__ == "__main__":
+    test_pfix()

--- a/tests/test_pfix.py
+++ b/tests/test_pfix.py
@@ -1,3 +1,4 @@
+import pytest
 import numpy as np
 import SeismicMesh
 

--- a/tests/test_pfix.py
+++ b/tests/test_pfix.py
@@ -2,6 +2,7 @@ import numpy as np
 import SeismicMesh
 
 
+@pytest.mark.serial
 def test_pfix():
     hmin = 0.05
     bbox = (0.0, 1.0, 0.0, 1.0, 0.0, 1.0)


### PR DESCRIPTION
* If user passed `pfix`, previously CGAL finite vertex iterator could scramble the location of `pfix`.
* Now if the user passed `pfix`, the program calculates the location of these points in the mesh and finds their index each iteration. 

* Need a test.

* MWE 

```
 import numpy as np
 import SeismicMesh
 
 import meshio
 
 hmin = 0.05
 
 pfix = np.linspace((0.0, 0.0, 0.0), (1.0, 0.0, 1.0), int(np.sqrt(2) / hmin))
 
 cube = SeismicMesh.Cube((0.0, 1.0, 0.0, 1.0, 0.0, 1.0))
 
 points, cells = SeismicMesh.generate_mesh(domain=cube, edge_length=hmin, pfix=pfix)
 meshio.write_points_cells(
     "cube_wpfix.vtk",
     points,
     [("tetra", cells)],
     file_format="vtk",
 )
``` 