### PR TITLE
speeding up boundary vertices calc

### DIFF
--- a/SeismicMesh/generation/mesh_generator.py
+++ b/SeismicMesh/generation/mesh_generator.py
@@ -682,11 +682,9 @@ def _remove_triangles_outside(p, t, fd, geps):
 def _improve_level_set_newton(p, t, fd, deps, tol):
     """Reduce level set error by using Newton's minimization method"""
     dim = p.shape[1]
-    max, abs = np.amax, np.abs
     bid = geometry.get_boundary_vertices(t, dim)
-    it = 0
     d = fd(p[bid])
-    while max(abs(d)) > tol and it < 10:
+    for _ in range(5):
 
         def _deps_vec(i):
             a = [0] * dim
@@ -697,7 +695,6 @@ def _improve_level_set_newton(p, t, fd, deps, tol):
         dgrad2 = sum(dgrad ** 2 for dgrad in dgrads)
         dgrad2 = np.where(dgrad2 < deps, deps, dgrad2)
         p[bid] -= (d * np.vstack(dgrads) / dgrad2).T  # Project
-        it += 1
     return p
 
 

--- a/SeismicMesh/geometry/utils.py
+++ b/SeismicMesh/geometry/utils.py
@@ -1,5 +1,4 @@
 import numpy as np
-from scipy.stats import mode
 import scipy.sparse as spsparse
 
 from ..generation.cpp import c_cgal

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = SeismicMesh
-version = 3.1.0
+version = 3.1.1
 url = https://github.com/krober10nd/SeismicMesh
 author = Keith Roberts
 email = keithrbt0@gmail.com


### PR DESCRIPTION
* the calculation of boundary vertices was needlessly slow previously.  
* with the help of @nschloe https://github.com/nschloe/meshplex/issues/81 a faster method to find these vertices was noted leading to ~3x speed-up in this calculation. 
* further, we do not need to run the `improve_level_set` method 10 times at the the end of mesh generation. Anecdotal evidence shows 5 works fine to improve dents in the boundary #82 
* With that said, this change is only meaningful with very large meshes (> 30 million cells or so) as in smaller meshes this step is otherwise relatively small and constant. 