### PR TITLE
improving 3d robustness

### DIFF
--- a/SeismicMesh/generation/mesh_generator.py
+++ b/SeismicMesh/generation/mesh_generator.py
@@ -399,6 +399,7 @@ def generate_mesh(domain, edge_length, comm=None, **kwargs):  # noqa: C901
         corners = corners[fd(corners) > -1000 * deps]
         pfix = np.append(pfix, corners, axis=0)
         nfix = len(pfix)
+
     if comm.rank == 0:
         print_msg1("Constraining " + str(nfix) + " fixed points..")
 
@@ -408,14 +409,8 @@ def generate_mesh(domain, edge_length, comm=None, **kwargs):  # noqa: C901
 
     if gen_opts["max_iter"] < 0:
         raise ValueError("`max_iter` must be > 0")
+
     max_iter = gen_opts["max_iter"]
-    if max_iter == 50:
-        # automatic max_iter selection based on resolution disparity
-        ms = np.amax(fh(p)) / np.amin(fh(p))
-        msmax = comm.allreduce(ms, op=MPI.MAX)
-        if msmax > 5:
-            max_iter = np.floor(50 * (msmax / 4))
-            print_msg1("Multiscale mesh: increasing max_iter to " + str(max_iter))
 
     N = p.shape[0]
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = SeismicMesh
-version = 3.1.1
+version = 3.1.2
 url = https://github.com/krober10nd/SeismicMesh
 author = Keith Roberts
 email = keithrbt0@gmail.com


### PR DESCRIPTION
* the boundary projection step is problematic in removing slivers as it can introduce more slivers than it removes. If a mesh was iterated with sufficiently, then this will hardly affect the representation of the boundary. 

* ~~Introducing a new automatic selection of the `max_iter` parameter in `generate_mesh` to improve the robustness of `sliver_removal`. Based on experimentation, if the ratio of the maximum to minimum resolution exceeds 5, then the number of iterations should be increased. Specifically, I multiply the default `max_iter` (50 iterations) to the floor of the max/min edge length ratio divided by 4. So a triangulation with a difference of 12 times in the maximum to minimum edge length should perform 150 meshing iterations rather than 50 iterations.~~



