### PR TITLE
critical bug fix to corners

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,11 +483,17 @@ Changelog
 =========
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project (tries to) adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+- None
+
+## [3.1.2] - 2020-11-04
 ### Improved
-- Faster calculation of boundary vertices. 
+- Faster calculation of boundary vertices.
+- More robust sliver removal in 3D.
+### Fixed
+- Corners are only constrained for constant resolution meshes
 
 ## [3.1.0] - 2020-10-28
 ### Added
@@ -495,7 +501,7 @@ and this project (tries to) adhere to [Semantic Versioning](https://semver.org/s
 - Updated images on README.
 ### Fixed
 - Only constrain corners near 0-level set.
-- Bug fix to 3D binary velocity reading. 
+- Bug fix to 3D binary velocity reading.
 
 ## [3.0.6] - 2020-10-21
 ### Fixed

--- a/SeismicMesh/generation/mesh_generator.py
+++ b/SeismicMesh/generation/mesh_generator.py
@@ -484,7 +484,7 @@ def generate_mesh(domain, edge_length, comm=None, **kwargs):  # noqa: C901
                 % (count + 1, maxdp, len(p), len(t)),
             )
             assert (
-                maxdp < 10 * h0
+                maxdp < 50 * h0
             ), "max movement indicates there's a convergence problem"
 
         count += 1

--- a/SeismicMesh/generation/mesh_generator.py
+++ b/SeismicMesh/generation/mesh_generator.py
@@ -351,6 +351,10 @@ def generate_mesh(domain, edge_length, comm=None, **kwargs):  # noqa: C901
     # unpack domain
     fd, bbox0, corners = _unpack_domain(domain, gen_opts)
 
+    # discard corners for now
+    if not np.isscalar(edge_length):
+        corners = None
+
     fh, bbox1, hmin = _unpack_sizing(edge_length)
 
     # take maxmin of boxes for the case of domain padding
@@ -479,6 +483,9 @@ def generate_mesh(domain, edge_length, comm=None, **kwargs):  # noqa: C901
                 "Iteration #%d, max movement is %f, there are %d vertices and %d cells"
                 % (count + 1, maxdp, len(p), len(t)),
             )
+            assert (
+                maxdp < 10 * h0
+            ), "max movement indicates there's a convergence problem"
 
         count += 1
 


### PR DESCRIPTION
* corners created problems for non-constant resolution meshes. 
* For now, only constrain corners for scalar edge length domains (constant resolution) until I can figure out a better fix. 
* Some corners would create massive triangles that would throw off the mesh generation convergence leading to a low quality mesh. 
* Put in an assert to shut down mesh generation if something is obviously wrong with convergence.