### PR TITLE
more control over grad option

### DIFF
--- a/SeismicMesh/sizing/mesh_size_function.py
+++ b/SeismicMesh/sizing/mesh_size_function.py
@@ -191,13 +191,6 @@ def get_sizing_function_from_segy(filename, bbox, comm=None, **kwargs):
 
         cell_size, vp, bbox = _build_domain_pad(cell_size, vp, bbox, opts)
 
-        import matplotlib.pyplot as plt
-
-        plt.pcolor(cell_size[:, :, 50])
-        plt.colorbar()
-        plt.show()
-        # quit()
-
         fh = _build_sizing_function(cell_size, vp, bbox)
     else:
 

--- a/SeismicMesh/sizing/mesh_size_function.py
+++ b/SeismicMesh/sizing/mesh_size_function.py
@@ -40,6 +40,7 @@ opts = {
     "freq": 2.0,
     "grad": 0.0,
     "grade": 0.0,
+    "stencil_size": 10.0,
     "space_order": 1,
     "dt": 0.0,
     "cr_max": 1.0,
@@ -78,6 +79,9 @@ def get_sizing_function_from_segy(filename, bbox, comm=None, **kwargs):
             𝑓𝑚𝑎𝑥 in hertz for which to estimate `wl` (default==2 Hertz)
         * *grad* (``float``) --
             Resolution in meters nearby sharp gradients in velociy (default==0 m)
+        * *stencil_size* (``int`` or ``tuple of ints``) --
+            Size of stencil in grid points to calculate variance of velocity to
+            assign mesh resolution with the *grad* option (default==10 grid points)
         * *grade* (``float``) --
             Maximum allowable variation in mesh size in decimal percent (default==0.0)
         * *space_order* (``int``) --
@@ -149,6 +153,7 @@ def get_sizing_function_from_segy(filename, bbox, comm=None, **kwargs):
                 "space_order",
                 "grad",
                 "grade",
+                "stencil_size",
                 "pad_style",
                 "domain_pad",
                 "units",
@@ -167,7 +172,7 @@ def get_sizing_function_from_segy(filename, bbox, comm=None, **kwargs):
         if np.any([opts["wl"] > 0, opts["grad"] > 0]):
             cell_size = np.minimum(
                 _wavelength_sizing(vp, opts["wl"], opts["freq"]),
-                _gradient_sizing(vp, opts["grad"]),
+                _gradient_sizing(vp, opts["grad"], opts["stencil_size"]),
             )
 
         print("Enforcing minimum edge length of " + str(opts["hmin"]))
@@ -185,6 +190,13 @@ def get_sizing_function_from_segy(filename, bbox, comm=None, **kwargs):
         )
 
         cell_size, vp, bbox = _build_domain_pad(cell_size, vp, bbox, opts)
+
+        import matplotlib.pyplot as plt
+
+        plt.pcolor(cell_size[:, :, 50])
+        plt.colorbar()
+        plt.show()
+        # quit()
 
         fh = _build_sizing_function(cell_size, vp, bbox)
     else:
@@ -353,7 +365,7 @@ def _wavelength_sizing(vp, wl=5, freq=2.0):
     return vp / (freq * wl)
 
 
-def _gradient_sizing(vp, grad):
+def _gradient_sizing(vp, grad, stencil_size):
     """Refine the mesh near sharp gradients in seismic velocity."""
     if grad == 0.0:
         return 99999
@@ -361,10 +373,14 @@ def _gradient_sizing(vp, grad):
     if grad < 0:
         raise ValueError("Parameter grad must be > 0")
 
-    window = [100] * vp.ndim
+    if np.isscalar(stencil_size):
+        window = [stencil_size] * vp.ndim
+    else:
+        window = stencil_size
     win_mean = ndimage.uniform_filter(vp, tuple(window))
     win_sqr_mean = ndimage.uniform_filter(vp ** 2, tuple(window))
     win_var = win_sqr_mean - win_mean ** 2
+
     # normalize variance to [0,1]
     win_var /= np.amax(win_var)
     win_var -= np.amin(win_var)

--- a/tests/test_2dmesher_domain_extension.py
+++ b/tests/test_2dmesher_domain_extension.py
@@ -37,6 +37,7 @@ def test_2dmesher_domain_extension(style_answer):
         bbox=bbox,
         grade=grade,
         grad=grad,
+        stencil_size=100,
         wl=wl,
         freq=freq,
         hmin=hmin,


### PR DESCRIPTION
* When thin rock layers  are present such as thin anhydrite layers, the user may want to target finer resolution on these layers.
* To accomplish this, the variance of the velocity field is calculated using sliding windows with a stencil size of a certain number of grid points in each dimension. The variance is normalized to [0,1] and the highest variance is assigned the resolution `grad`. 
* With this PR, the user can now control the sliding window to calculate the variance with the sizing options `stencil_size` in addition to the existing `grad` option.

Obviously, the `stencil_size` and `grad` options depend on the model at hand but a simple example of this is resolving a thin layer with finer resolution like depicted in the figure.

![Example](https://user-images.githubusercontent.com/18619644/98150223-1676ec00-1ead-11eb-9e71-c63aaff4aa99.png)
