### PR TITLE
fix reversal of height and width in cylinder

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,6 +483,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Fixed
+- Cylinder radius and height are now correct.
+
 ### Improved
 - More control over the `grad` option in the mesh sizing function.
 

--- a/SeismicMesh/geometry/signed_distance_functions.py
+++ b/SeismicMesh/geometry/signed_distance_functions.py
@@ -194,8 +194,9 @@ class Prism:
 class Cylinder:
     def __init__(self, h=1.0, r=0.5):
         assert h > 0.0 or r > 0.0
-        self.bbox = (-2 * r, 2 * r, -2 * r, 2 * r, -2 * h, 2 * h)
-        self.h = (h, r)
+        sz = max(h, r)
+        self.bbox = (-2 * sz, 2 * sz, -2 * sz, 2 * sz, -2 * sz, 2 * sz)
+        self.h = (r, h)
         self.corners = None
 
     def eval(self, x):


### PR DESCRIPTION
* radius `r` and height `h` of cylinder were mismatched. 
* this fixes that. 