### PR TITLE
dampening in Newton optmi.

### DIFF
--- a/README.md
+++ b/README.md
@@ -511,9 +511,13 @@ Changelog
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## Unreleased 
+- None
+
+## [3.1.5] - 2020-11-24
 - Support for constraining/immersing subdomains represented as signed distance functions.
 - Faster cell manipulation operations for ~5-10% better speedups in parallel. 
+- Projection of points back onto level set.
 
 ## [3.1.4] - 2020-11-15
 - Laplacian smoothing at termination for 2D meshing...significantly improves minimum cell quality.

--- a/SeismicMesh/generation/mesh_generator.py
+++ b/SeismicMesh/generation/mesh_generator.py
@@ -720,7 +720,6 @@ def _improve_level_set_newton(p, t, fd, deps, tol):
     alpha = 1
     for iteration in range(5):
         d = fd(p[bid])
-        print(np.amax(np.abs(d)))
 
         def _deps_vec(i):
             a = [0] * dim

--- a/SeismicMesh/generation/mesh_generator.py
+++ b/SeismicMesh/generation/mesh_generator.py
@@ -170,6 +170,7 @@ def sliver_removal(points, domain, edge_length, comm=None, **kwargs):  # noqa: C
     )
 
     geps = sliver_opts["geps_mult"] * h0
+    deps = np.sqrt(np.finfo(np.double).eps) * h0
     min_dh_bound = sliver_opts["min_dh_angle_bound"] * math.pi / 180
     max_dh_bound = sliver_opts["max_dh_angle_bound"] * math.pi / 180
 
@@ -247,6 +248,8 @@ def sliver_removal(points, domain, edge_length, comm=None, **kwargs):  # noqa: C
                 + " iterations...no slivers detected!",
             )
             p, t, _ = geometry.fix_mesh(p, t, dim=dim, delete_unused=True)
+            p = _improve_level_set_newton(p, t, fd, deps, deps * 1000)
+            ele_nums, ix = _calc_dihedral_angles(p, t, min_dh_bound, max_dh_bound)
             return p, t
 
         p0, p1, p2, p3 = (
@@ -715,8 +718,10 @@ def _improve_level_set_newton(p, t, fd, deps, tol):
     """Reduce level set error by using Newton's minimization method"""
     dim = p.shape[1]
     bid = geometry.get_boundary_vertices(t, dim)
-    for _ in range(5):
+    alpha = 1
+    for iteration in range(5):
         d = fd(p[bid])
+        print(np.amax(np.abs(d)))
 
         def _deps_vec(i):
             a = [0] * dim
@@ -726,7 +731,8 @@ def _improve_level_set_newton(p, t, fd, deps, tol):
         dgrads = [(fd(p[bid] + _deps_vec(i)) - d) / deps for i in range(dim)]
         dgrad2 = sum(dgrad ** 2 for dgrad in dgrads)
         dgrad2 = np.where(dgrad2 < deps, deps, dgrad2)
-        p[bid] -= (d * np.vstack(dgrads) / dgrad2).T  # Project
+        p[bid] -= alpha * (d * np.vstack(dgrads) / dgrad2).T  # Project
+        alpha /= iteration + 1
     return p
 
 

--- a/SeismicMesh/generation/mesh_generator.py
+++ b/SeismicMesh/generation/mesh_generator.py
@@ -249,7 +249,6 @@ def sliver_removal(points, domain, edge_length, comm=None, **kwargs):  # noqa: C
             )
             p, t, _ = geometry.fix_mesh(p, t, dim=dim, delete_unused=True)
             p = _improve_level_set_newton(p, t, fd, deps, deps * 1000)
-            ele_nums, ix = _calc_dihedral_angles(p, t, min_dh_bound, max_dh_bound)
             return p, t
 
         p0, p1, p2, p3 = (

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = SeismicMesh
-version = 3.1.4
+version = 3.1.5
 url = https://github.com/krober10nd/SeismicMesh
 author = Keith Roberts
 email = keithrbt0@gmail.com


### PR DESCRIPTION
* at the end of both mesh generation *and* sliver removal, a multi-Newton optimization problem is now solved to project boundary vertices exactly onto the boundary. This process is repeated five times as before but now with a progressively dampening step `alpha`.  Prior, it was only solved at the end of mesh generation. 
* This step halving prevents overshooting the global minimum (all boundary vertices lying on the level set) and now we can achieve extremely accurate conformity of the 0-level set with no dents. Maximum distance of a boundary vertex to the 0-level set is ~1e-16 in the visualized EAGE example
* @nschloe maybe interesting for `dmsh`? The halving dampening coefficient is heuristic but seems to work well.. 

![w_newton_method](https://user-images.githubusercontent.com/18619644/100124743-cca17600-2e5a-11eb-9188-180546b377aa.png)

![w_newton_method2](https://user-images.githubusercontent.com/18619644/100124726-c7442b80-2e5a-11eb-8f93-b8f242ee158c.png)
