### PR TITLE
testing 3d sliver removal + 2d min. qualities

### DIFF
--- a/SeismicMesh/generation/mesh_generator.py
+++ b/SeismicMesh/generation/mesh_generator.py
@@ -170,7 +170,7 @@ def sliver_removal(points, domain, edge_length, comm=None, **kwargs):  # noqa: C
     )
 
     geps = sliver_opts["geps_mult"] * h0
-    deps = np.sqrt(np.finfo(np.double).eps) * h0
+    #deps = np.sqrt(np.finfo(np.double).eps) * h0
     min_dh_bound = sliver_opts["min_dh_angle_bound"] * math.pi / 180
     max_dh_bound = sliver_opts["max_dh_angle_bound"] * math.pi / 180
 

--- a/SeismicMesh/generation/mesh_generator.py
+++ b/SeismicMesh/generation/mesh_generator.py
@@ -248,7 +248,7 @@ def sliver_removal(points, domain, edge_length, comm=None, **kwargs):  # noqa: C
                 + " iterations...no slivers detected!",
             )
             p, t, _ = geometry.fix_mesh(p, t, dim=dim, delete_unused=True)
-            p = _improve_level_set_newton(p, t, fd, deps, deps * 1000)
+            #p = _improve_level_set_newton(p, t, fd, deps, deps * 1000)
             return p, t
 
         p0, p1, p2, p3 = (

--- a/SeismicMesh/generation/mesh_generator.py
+++ b/SeismicMesh/generation/mesh_generator.py
@@ -248,7 +248,7 @@ def sliver_removal(points, domain, edge_length, comm=None, **kwargs):  # noqa: C
                 + " iterations...no slivers detected!",
             )
             p, t, _ = geometry.fix_mesh(p, t, dim=dim, delete_unused=True)
-            #p = _improve_level_set_newton(p, t, fd, deps, deps * 1000)
+            # p = _improve_level_set_newton(p, t, fd, deps, deps * 1000)
             return p, t
 
         p0, p1, p2, p3 = (

--- a/SeismicMesh/generation/mesh_generator.py
+++ b/SeismicMesh/generation/mesh_generator.py
@@ -170,7 +170,7 @@ def sliver_removal(points, domain, edge_length, comm=None, **kwargs):  # noqa: C
     )
 
     geps = sliver_opts["geps_mult"] * h0
-    #deps = np.sqrt(np.finfo(np.double).eps) * h0
+    # deps = np.sqrt(np.finfo(np.double).eps) * h0
     min_dh_bound = sliver_opts["min_dh_angle_bound"] * math.pi / 180
     max_dh_bound = sliver_opts["max_dh_angle_bound"] * math.pi / 180
 

--- a/tests/test_2d_min_qual.py
+++ b/tests/test_2d_min_qual.py
@@ -1,0 +1,31 @@
+import numpy as np
+import pytest
+
+import SeismicMesh
+
+
+def quarter_annulus(h):
+    rect = SeismicMesh.Rectangle((0.0, 1.0, 0.0, 1.0))
+    disk0 = SeismicMesh.Disk([0.0, 0.0], 0.25)
+    diff0 = SeismicMesh.Difference([rect, disk0])
+
+    disk1 = SeismicMesh.Disk([0.0, 0.0], 1.0)
+    quarter = SeismicMesh.Intersection([diff0, disk1])
+
+    points, cells = SeismicMesh.generate_mesh(
+        domain=quarter,
+        edge_length=lambda x: h + 0.1 * np.abs(disk0.eval(x)),
+        h0=h,
+        verbose=0,
+    )
+    return points, cells
+
+
+@pytest.mark.serial
+def test_2d_min_qual():
+
+    hmins = np.logspace(-1.0, -2.0, num=5)
+    for h in hmins:
+        points, cells = quarter_annulus(h)
+        quals = SeismicMesh.geometry.simp_qual(points, cells)
+        assert np.amin(quals) > 0.60

--- a/tests/test_3d_sliver.py
+++ b/tests/test_3d_sliver.py
@@ -7,21 +7,52 @@ import SeismicMesh
 
 def cylinder(h):
     cylinder = SeismicMesh.Cylinder(h=1.0, r=1.0)
-    points, cells = SeismicMesh.generate_mesh(domain=cylinder, edge_length=h, verbose=1)
+    points, cells = SeismicMesh.generate_mesh(domain=cylinder, edge_length=h, verbose=0)
     points, cells = SeismicMesh.sliver_removal(
-        points=points, domain=cylinder, edge_length=h, verbose=1
+        points=points, domain=cylinder, edge_length=h, verbose=0
+    )
+    return points, cells
+
+
+def l_shape_3d(h):
+    tol = h / 10
+
+    cube0 = SeismicMesh.Cube((-1.0, 1.0, -1.0, 1.0, -1.0, tol))
+    cube1 = SeismicMesh.Cube((-1.0, 1.0, 0.0, 1.0, -tol, 1.0))
+    cube2 = SeismicMesh.Cube((-tol, 1.0, -1.0, 1.0, -tol, 1.0))
+    domain = SeismicMesh.Union([cube0, cube1, cube2])
+
+    points, cells = SeismicMesh.generate_mesh(domain=domain, edge_length=h, verbose=0)
+    points, cells = SeismicMesh.sliver_removal(
+        domain=domain, points=points, edge_length=h, verbose=0
     )
     return points, cells
 
 
 @pytest.mark.serial
-def test_3d_sliver():
+def test_3d_sliver_cylinder():
 
-    hmins = np.logspace(-1.0, -1.5, num=5)
+    hmins = np.logspace(-1.0, -1.3, num=5)
     min_dh_bound = 10 * math.pi / 180
     max_dh_bound = 180 * math.pi / 180
     for h in hmins:
         points, cells = cylinder(h)
+        dh_angles = SeismicMesh.geometry.calc_dihedral_angles(points, cells)
+        out_of_bounds = np.argwhere(
+            (dh_angles[:, 0] < min_dh_bound) | (dh_angles[:, 0] > max_dh_bound)
+        )
+        ele_nums = np.floor(out_of_bounds / 6).astype("int")
+        ele_nums, ix = np.unique(ele_nums, return_index=True)
+        assert len(ele_nums) == 0
+
+
+@pytest.mark.serial
+def test_3d_sliver_box3d():
+    hmins = np.logspace(-1.0, -1.2, num=5)
+    min_dh_bound = 10 * math.pi / 180
+    max_dh_bound = 180 * math.pi / 180
+    for h in hmins:
+        points, cells = l_shape_3d(h)
         dh_angles = SeismicMesh.geometry.calc_dihedral_angles(points, cells)
         out_of_bounds = np.argwhere(
             (dh_angles[:, 0] < min_dh_bound) | (dh_angles[:, 0] > max_dh_bound)

--- a/tests/test_3d_sliver.py
+++ b/tests/test_3d_sliver.py
@@ -1,0 +1,31 @@
+import numpy as np
+import math
+import pytest
+
+import SeismicMesh
+
+
+def cylinder(h):
+    cylinder = SeismicMesh.Cylinder(h=1.0, r=1.0)
+    points, cells = SeismicMesh.generate_mesh(domain=cylinder, edge_length=h, verbose=1)
+    points, cells = SeismicMesh.sliver_removal(
+        points=points, domain=cylinder, edge_length=h, verbose=1
+    )
+    return points, cells
+
+
+@pytest.mark.serial
+def test_3d_sliver():
+
+    hmins = np.logspace(-1.0, -1.5, num=5)
+    min_dh_bound = 10 * math.pi / 180
+    max_dh_bound = 180 * math.pi / 180
+    for h in hmins:
+        points, cells = cylinder(h)
+        dh_angles = SeismicMesh.geometry.calc_dihedral_angles(points, cells)
+        out_of_bounds = np.argwhere(
+            (dh_angles[:, 0] < min_dh_bound) | (dh_angles[:, 0] > max_dh_bound)
+        )
+        ele_nums = np.floor(out_of_bounds / 6).astype("int")
+        ele_nums, ix = np.unique(ele_nums, return_index=True)
+        assert len(ele_nums) == 0


### PR DESCRIPTION
* Thanks to @nschloe, I've discovered a new problem with the 3d boundary improvement strategy. 
* 3d boundary improvement at the end of sliver removal can create new slivers.
* I disable it for now and created a test so this doesn't happen again and we can catch failures of the sliver removal. 
* May add another domain for robustness?