### PR TITLE
boundary projection steps for some primitives

### DIFF
--- a/SeismicMesh/generation/mesh_generator.py
+++ b/SeismicMesh/generation/mesh_generator.py
@@ -278,7 +278,7 @@ def sliver_removal(points, domain, edge_length, comm=None, **kwargs):  # noqa: C
         # for some primitives so do it every iteration
         if np.any([isinstance(domain, d) for d in boundary_step_domains]):
             d = fd(p)
-            p[d > geps, :] = domain.boundary_step(p[d > geps, :], snap=True)
+            p[d > -geps, :] = domain.boundary_step(p[d > -geps, :], snap=True)
 
         count += 1
 
@@ -510,8 +510,8 @@ def generate_mesh(domain, edge_length, comm=None, **kwargs):  # noqa: C901
             if idx == 0 and np.any(
                 [isinstance(domain, d) for d in boundary_step_domains]
             ):
-                d = fd(p)
-                p[d > geps, :] = domain.boundary_step(p[d > geps, :], snap=True)
+                d = level(p)
+                p[d > 0.0, :] = domain.boundary_step(p[d > 0.0, :], snap=False)
             else:
                 p = _project_points_back_newton(p, level, deps, h0, idx)
 

--- a/SeismicMesh/generation/mesh_generator.py
+++ b/SeismicMesh/generation/mesh_generator.py
@@ -198,12 +198,7 @@ def sliver_removal(points, domain, edge_length, comm=None, **kwargs):  # noqa: C
     count = 0
     pold = None
     push = 0.10
-
-    # these domains have boundary_step methods
-    boundary_step_domains = [
-        geometry.Rectangle,
-        geometry.Cube,
-    ]
+    deps = np.sqrt(np.finfo(np.double).eps) * h0
 
     dt = DT()
     dt.insert(p.flatten().tolist())
@@ -274,11 +269,8 @@ def sliver_removal(points, domain, edge_length, comm=None, **kwargs):  # noqa: C
         # perturb push % of minimum mesh size
         p[move] += push * h0 * perturb
 
-        # the boundary projection step is quite light
-        # for some primitives so do it every iteration
-        if np.any([isinstance(domain, d) for d in boundary_step_domains]):
-            d = fd(p)
-            p[d > -geps, :] = domain.boundary_step(p[d > -geps, :], snap=True)
+        # the boundary projection step
+        p = _improve_level_set_newton(p, t, fd, deps, deps * 1000)
 
         count += 1
 

--- a/SeismicMesh/generation/mesh_generator.py
+++ b/SeismicMesh/generation/mesh_generator.py
@@ -147,6 +147,7 @@ def sliver_removal(points, domain, edge_length, comm=None, **kwargs):  # noqa: C
     # rebuild the Rectangle or Cube if domain padding
     if bbox0 != bbox1 and bbox1 is not None:
         fd = geometry.Cube(bbox).eval
+        domain.bbox = bbox
 
     if not isinstance(bbox, tuple):
         raise ValueError("`bbox` must be a tuple")
@@ -393,6 +394,7 @@ def generate_mesh(domain, edge_length, comm=None, **kwargs):  # noqa: C901
             tmp = geometry.Cube(bbox)
 
         fd = tmp.eval
+        domain.bbox = bbox
 
     bbox = np.array(bbox).reshape(-1, 2)
 

--- a/SeismicMesh/generation/mesh_generator.py
+++ b/SeismicMesh/generation/mesh_generator.py
@@ -274,10 +274,11 @@ def sliver_removal(points, domain, edge_length, comm=None, **kwargs):  # noqa: C
         # perturb push % of minimum mesh size
         p[move] += push * h0 * perturb
 
-        # if a cube/rectangle, the boundary projection step is quite light
-        # so do it every iteration
+        # the boundary projection step is quite light
+        # for some primitives so do it every iteration
         if np.any([isinstance(domain, d) for d in boundary_step_domains]):
-            p = domain.boundary_step(p)
+            d = fd(p)
+            p[d > geps, :] = domain.boundary_step(p[d > geps, :], snap=True)
 
         count += 1
 
@@ -509,7 +510,8 @@ def generate_mesh(domain, edge_length, comm=None, **kwargs):  # noqa: C901
             if idx == 0 and np.any(
                 [isinstance(domain, d) for d in boundary_step_domains]
             ):
-                p = domain.boundary_step(p)
+                d = fd(p)
+                p[d > geps, :] = domain.boundary_step(p[d > geps, :], snap=True)
             else:
                 p = _project_points_back_newton(p, level, deps, h0, idx)
 

--- a/SeismicMesh/geometry/signed_distance_functions.py
+++ b/SeismicMesh/geometry/signed_distance_functions.py
@@ -157,7 +157,9 @@ class Rectangle:
         return drectangle(x, self.bbox[0], self.bbox[1], self.bbox[2], self.bbox[3])
 
     def boundary_step(self, x, snap=False):
-        """Project points outside of a rectangle back in"""
+        """Project points outside of a rectangle back in
+        inspired by https://github.com/nschloe/dmsh/blob/20adbe5956b0e26ef54c0a4994185fe46a9609f8/dmsh/geometry/rectangle.py#L57
+        """
         x0, x1, y0, y1 = self.bbox
 
         cx = (x0 + x1) / 2

--- a/SeismicMesh/geometry/signed_distance_functions.py
+++ b/SeismicMesh/geometry/signed_distance_functions.py
@@ -156,6 +156,29 @@ class Rectangle:
     def eval(self, x):
         return drectangle(x, self.bbox[0], self.bbox[1], self.bbox[2], self.bbox[3])
 
+    def boundary_step(self, x):
+        """Project points outside of a rectangle back in"""
+        x0, x1, y0, y1 = self.bbox
+
+        cx = (x0 + x1) / 2
+        cy = (y0 + y1) / 2
+        w = x1 - x0
+        h = y1 - y0
+
+        X = x[:, 0] - cx
+        Y = x[:, 1] - cy
+
+        X[X < -w / 2] = -w / 2
+        X[X > +w / 2] = +w / 2
+        Y[Y < -h / 2] = -h / 2
+        Y[Y > +h / 2] = +h / 2
+
+        X += cx
+        Y += cy
+
+        out = np.column_stack([X, Y])
+        return out
+
 
 class Cube:
     def __init__(self, bbox):
@@ -173,6 +196,35 @@ class Cube:
             self.bbox[4],
             self.bbox[5],
         )
+
+    def boundary_step(self, x):
+        """Project points outside of a cuboid back in"""
+        x0, x1, y0, y1, z0, z1 = self.bbox
+
+        cx = (x0 + x1) / 2
+        cy = (y0 + y1) / 2
+        cz = (z0 + z1) / 2
+        w = x1 - x0
+        h = y1 - y0
+        le = z1 - z0
+
+        X = x[:, 0] - cx
+        Y = x[:, 1] - cy
+        Z = x[:, 2] - cz
+
+        X[X < -w / 2] = -w / 2
+        X[X > +w / 2] = +w / 2
+        Y[Y < -h / 2] = -h / 2
+        Y[Y > +h / 2] = +h / 2
+        Z[Z < -le / 2] = -le / 2
+        Z[Z > +le / 2] = +le / 2
+
+        X += cx
+        Y += cy
+        Z += cz
+
+        out = np.column_stack([X, Y, Z])
+        return out
 
 
 class Torus:

--- a/SeismicMesh/geometry/signed_distance_functions.py
+++ b/SeismicMesh/geometry/signed_distance_functions.py
@@ -263,15 +263,11 @@ class Cube:
                 above = p_in[dmy, closest_face] > 0.0
                 below = p_in[dmy, closest_face] < 0.0
 
-                # snap to faces
+                # snap to faces (needs more work)
                 if np.any(above):
-                    p_in[above == True, closest_face] = axes_up_bound[
-                        above == True, closest_face
-                    ]
+                    p_in[above, closest_face] = axes_up_bound[above, closest_face]
                 if np.any(below):
-                    p_in[below == True, closest_face] = axes_low_bound[
-                        below == True, closest_face
-                    ]
+                    p_in[below, closest_face] = axes_low_bound[below, closest_face]
 
                 X[is_interior] = p_in[:, 0]
                 Y[is_interior] = p_in[:, 1]


### PR DESCRIPTION
* `Rectangle` and `Cube` now have a `boundary_step` method since projecting points onto their boundaries is trivial. 
