### PR TITLE
optional preserve level-set

### DIFF
--- a/README.md
+++ b/README.md
@@ -593,6 +593,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Ability to improve accuracy of level-set when performing 3d sliver removal.
 ### Improved
 - Marginally faster parallel speedup at scale in 2d/3d 
 

--- a/SeismicMesh/generation/mesh_generator.py
+++ b/SeismicMesh/generation/mesh_generator.py
@@ -115,6 +115,7 @@ def sliver_removal(points, domain, edge_length, comm=None, **kwargs):  # noqa: C
         "geps_mult": 0.1,
         "subdomains": [],
         "gamma": 1.0,
+        "preserve": False,
     }
 
     sliver_opts.update(kwargs)
@@ -172,7 +173,7 @@ def sliver_removal(points, domain, edge_length, comm=None, **kwargs):  # noqa: C
 
     geps = sliver_opts["geps_mult"] * h0
 
-    # deps = np.sqrt(np.finfo(np.double).eps) * h0
+    deps = np.sqrt(np.finfo(np.double).eps) * h0
     min_dh_bound = sliver_opts["min_dh_angle_bound"] * math.pi / 180
     max_dh_bound = sliver_opts["max_dh_angle_bound"] * math.pi / 180
 
@@ -252,7 +253,6 @@ def sliver_removal(points, domain, edge_length, comm=None, **kwargs):  # noqa: C
                 + " iterations...no slivers detected!",
             )
             p, t, _ = geometry.fix_mesh(p, t, dim=dim, delete_unused=True)
-            # p = _improve_level_set_newton(p, t, fd, deps, deps * 1000)
             return p, t
 
         p0, p1, p2, p3 = (
@@ -285,6 +285,10 @@ def sliver_removal(points, domain, edge_length, comm=None, **kwargs):  # noqa: C
 
         # perturb step % of minimum mesh size
         p[move] += step * h0 * perturb
+
+        # reproject boundary points
+        if sliver_opts["preserve"]:
+            p = _improve_level_set_newton(p, t, fd, deps, deps * 1000)
 
         count += 1
 
@@ -641,6 +645,7 @@ def _parse_kwargs(kwargs):
             "geps_mult",
             "subdomains",
             "gamma",
+            "preserve",
         }:
             pass
         else:


### PR DESCRIPTION
* sliver removal can lead to less accurately preserved boundaries. 
* New option "preserve" (default False) will run an optimization problem each sliver removal iteration to increase the accuracy of the boundary at the cost of more time per iteration. 