### PR TITLE
Parallel user-defined mesh size functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ seismic velocity model from (WARNING: File is \~500 MB)**
 around 2 GB of RAM due to the 3D nature of the problem and the domain
 size.**
 
-![Above shows the mesh in ParaView that results from running the code below.](https://user-images.githubusercontent.com/18619644/91606008-c5e09100-e947-11ea-97e2-58e4b2f23d2b.jpg)
+![Above shows the mesh in ParaView that results from running the code below.](https://user-images.githubusercontent.com/18619644/103445790-52cd8b00-4c57-11eb-8bd4-4af8f24d4c88.jpg)
 
 <!--exdown-skip-->
 ```python
@@ -239,8 +239,9 @@ ef = get_sizing_function_from_segy(
 points, cells = generate_mesh(domain=cube, edge_length=ef, max_iter=75)
 
 # For 3D mesh generation, we provide an implementation to bound the minimum dihedral angle::
+# We use the preserve kwarg to ensure the level-set is very accurately preserved.
 points, cells = sliver_removal(
-    points=points, bbox=bbox, domain=cube, edge_length=ef
+    points=points, bbox=bbox, domain=cube, edge_length=ef, preserve=True
 )
 
 # Meshes can be written quickly to disk using meshio and visualized with ParaView::
@@ -596,14 +597,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Ability to improve accuracy of level-set when performing 3d sliver removal.
 ### Improved
-- Marginally faster parallel speedup at scale in 2d/3d 
+- Marginally faster parallel speedup at scale in 2d/3d
 
 ## [3.2.0] -2020-12-14
 ### Added
 - Adding basic periodic domains with the `Repeat` SDF.
 - `sliver_removal` has optional variable step size when perturbing vertices. Helps to remove the "last sliver".
 ### Improved
-- Faster rectangle and cube primitives. 
+- Faster rectangle and cube primitives.
 - Reworking CPP code and bottlenecks...20-30% faster `generate_mesh` in parallel for 2D/3D from previous versions.
 
 ## [3.1.7] - 2020-11-27

--- a/README.md
+++ b/README.md
@@ -623,6 +623,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- User can now mesh user-defined sizing functions in parallel (not from :class:SizeFunction)
 
 ## [3.3.0] -2021-01-08
 ### Added


### PR DESCRIPTION
* Handles the case running parallel mesh generation from a user-defined mesh sizing function. 
* mpiexec -n 2 python code_below.py
```
 from mpi4py import MPI
 import numpy
 import SeismicMesh
 import meshio
 
 comm = MPI.COMM_WORLD
 
 
 h = 0.05
 
 
 bbox = (0.0, 1.0, 0.0, 1.0, 0.0, 1.0)
 cube = SeismicMesh.geometry.Cube(bbox)
 
 
 def edge_length(x):
     return h + 0.05 * (numpy.abs(x[:, 0] - 1.0))
 
 
 points, cells = SeismicMesh.generate_mesh(
     bbox=bbox,
     h0=h,
     domain=cube,
     edge_length=edge_length,
     verbose=2,
 )
 points, cells = SeismicMesh.sliver_removal(
     points=points,
     bbox=bbox,
     h0=h,
     domain=cube,
     edge_length=edge_length,
 )
 
 meshio.write_points_cells(
     "cube.vtk",
     points,
     [("tetra", cells)],
     file_format="vtk",
 )
```